### PR TITLE
Add extended packet fields and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,20 @@ The client displays the last packets in the terminal while logging all measureme
 
 * **Request** (client ➜ server):
   * `uint32_t count` – number of `Packet` messages the client wants to receive.
+  * `uint64_t client_time_ns` – local time when sending the request.
+  * `uint32_t client_id` – identifier of the client session.
+  * `uint32_t payload_size` – desired payload size in bytes.
+  * `uint32_t tick_request_ms` – desired tick interval.
 * **Sync** (server ➜ client):
-  * `uint64_t server_time_ns` – server timestamp when the request was received. Used to estimate clock offset.
+  * `uint64_t server_time_ns` – server timestamp when the request was received.
+  * `uint32_t server_id` – identifier of the server.
+  * `uint32_t tick_ms` – tick interval that will actually be used. Used to estimate clock offset.
 * **Packet** (server ➜ client):
   * `uint32_t seq` – sequence number.
   * `uint64_t timestamp_ns` – server send timestamp in nanoseconds.
+  * `uint32_t server_id` – same identifier as in `Sync`.
+  * `uint32_t tick_ms` – tick interval used.
+  * payload – byte array of length `payload_size`.
 
 ## Latency calculation with unsynchronized clocks
 


### PR DESCRIPTION
## Summary
- expand Request with timing, ID, payload and tick info
- expand Sync and Packet with server id, tick interval and payload
- log additional information on both client and server
- update command line options and documentation

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6850f202d3ec83268d19f05e492b6290