### PR TITLE
Add basic Android client with network test and graph

### DIFF
--- a/android-client/app/build.gradle.kts
+++ b/android-client/app/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.2.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    implementation("com.jjoe64:graphview:4.2.2")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")

--- a/android-client/app/src/main/AndroidManifest.xml
+++ b/android-client/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/android-client/app/src/main/java/ar/com/telecom/speedtestgamer/MainActivity.kt
+++ b/android-client/app/src/main/java/ar/com/telecom/speedtestgamer/MainActivity.kt
@@ -1,11 +1,125 @@
 package ar.com.telecom.speedtestgamer
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import com.jjoe64.graphview.GraphView
+import com.jjoe64.graphview.series.DataPoint
+import com.jjoe64.graphview.series.LineGraphSeries
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 
 class MainActivity : AppCompatActivity() {
+
+    private lateinit var editIp: EditText
+    private lateinit var editPort: EditText
+    private lateinit var startButton: Button
+    private lateinit var statsView: TextView
+    private lateinit var graph: GraphView
+    private val series = LineGraphSeries<DataPoint>()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        editIp = findViewById(R.id.editIp)
+        editPort = findViewById(R.id.editPort)
+        startButton = findViewById(R.id.buttonStart)
+        statsView = findViewById(R.id.textStats)
+        graph = findViewById(R.id.graph)
+        graph.addSeries(series)
+
+        startButton.setOnClickListener {
+            startTest()
+        }
+    }
+
+    private fun startTest() {
+        series.resetData(arrayOf())
+        statsView.text = "Running..."
+        val ip = editIp.text.toString()
+        val port = editPort.text.toString().toIntOrNull() ?: return
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val result = runTest(ip, port)
+            withContext(Dispatchers.Main) {
+                statsView.text = result
+            }
+        }
+    }
+
+    private suspend fun runTest(ip: String, port: Int): String {
+        val count = 50
+        val payloadSize = 0
+        val tickMs = 0
+        val socket = DatagramSocket()
+        socket.soTimeout = 3000
+        val server = InetAddress.getByName(ip)
+
+        // build request
+        val bufReq = ByteBuffer.allocate(20).order(ByteOrder.LITTLE_ENDIAN)
+        bufReq.putInt(count)
+        val sendTime = System.nanoTime()
+        bufReq.putLong(sendTime)
+        bufReq.putInt(0) // client_id
+        bufReq.putInt(payloadSize)
+        bufReq.putInt(tickMs)
+        val reqData = bufReq.array()
+        socket.send(DatagramPacket(reqData, reqData.size, server, port))
+
+        // receive sync
+        val syncBuf = ByteArray(16)
+        val syncPacket = DatagramPacket(syncBuf, syncBuf.size)
+        socket.receive(syncPacket)
+        val recvTime = System.nanoTime()
+        val sync = ByteBuffer.wrap(syncBuf).order(ByteOrder.LITTLE_ENDIAN)
+        val serverTime = sync.long
+        sync.int // server_id
+        val usedTick = sync.int
+        val offset = serverTime - (sendTime + (recvTime - sendTime) / 2)
+
+        val latencies = mutableListOf<Double>()
+        var min = Double.MAX_VALUE
+        var max = 0.0
+        val packetBuf = ByteArray(1500)
+        for (i in 0 until count) {
+            val pkt = DatagramPacket(packetBuf, packetBuf.size)
+            socket.receive(pkt)
+            val now = System.nanoTime()
+            val hdr = ByteBuffer.wrap(pkt.data, 0, 20).order(ByteOrder.LITTLE_ENDIAN)
+            hdr.int // seq
+            val ts = hdr.long
+            hdr.int // server_id
+            hdr.int // tick
+            val latency = (now - (ts - offset)) / 1e6
+            latencies.add(latency)
+            if (latency < min) min = latency
+            if (latency > max) max = latency
+
+            withContext(Dispatchers.Main) {
+                series.appendData(DataPoint(i.toDouble(), latency), true, count)
+                val avg = latencies.average()
+                statsView.text = String.format(
+                    "Packets: %d Avg: %.2f ms Min: %.2f ms Max: %.2f ms",
+                    latencies.size, avg, min, max
+                )
+            }
+        }
+
+        socket.close()
+        val avg = latencies.average()
+        return String.format(
+            "Finished\nAvg: %.2f ms Min: %.2f ms Max: %.2f ms",
+            avg, min, max
+        )
     }
 }

--- a/android-client/app/src/main/res/layout/activity_main.xml
+++ b/android-client/app/src/main/res/layout/activity_main.xml
@@ -6,13 +6,53 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <TextView
+    <EditText
+        android:id="@+id/editIp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Server IP"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/editPort"
+        app:layout_constraintHorizontalWeight="1" />
+
+    <EditText
+        android:id="@+id/editPort"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="Port"
+        android:inputType="number"
+        app:layout_constraintStart_toEndOf="@id/editIp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/buttonStart"
+        app:layout_constraintHorizontalWeight="1" />
+
+    <Button
+        android:id="@+id/buttonStart"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:text="Start"
+        app:layout_constraintStart_toEndOf="@id/editPort"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <com.jjoe64.graphview.GraphView
+        android:id="@+id/graph"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@id/editIp"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/textStats" />
+
+    <TextView
+        android:id="@+id/textStats"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/stats_placeholder"
+        app:layout_constraintTop_toBottomOf="@id/graph"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-client/app/src/main/res/values/strings.xml
+++ b/android-client/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Speed Test Gamer</string>
+    <string name="stats_placeholder">Stats</string>
 </resources>


### PR DESCRIPTION
## Summary
- create UI for Android client including IP, port, start button and graph
- implement UDP speed test logic in `MainActivity`
- show realtime graph and stats
- add required INTERNET permission
- include coroutines and GraphView dependencies

## Testing
- `./gradlew tasks --all`

------
https://chatgpt.com/codex/tasks/task_e_6850f49774348326a3dadf94fe257305