### PR TITLE
Fix Android compileSdk

### DIFF
--- a/android-client/app/build.gradle.kts
+++ b/android-client/app/build.gradle.kts
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace = "ar.com.telecom.speedtestgamer"
-    compileSdk = 33
+    compileSdk = 34
 
     defaultConfig {
         applicationId = "ar.com.telecom.speedtestgamer"
         minSdk = 28
-        targetSdk = 33
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
 


### PR DESCRIPTION
## Summary
- update Android compileSdk and targetSdk to 34

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fb18ae888326a3228f66f2a16306