### PR TITLE
Fix buffer overflow on request creation

### DIFF
--- a/android-client/app/src/main/java/ar/com/telecom/speedtestgamer/MainActivity.kt
+++ b/android-client/app/src/main/java/ar/com/telecom/speedtestgamer/MainActivity.kt
@@ -101,7 +101,9 @@ class MainActivity : AppCompatActivity() {
         val server = InetAddress.getByName(ip)
 
         // build request
-        val bufReq = ByteBuffer.allocate(20).order(ByteOrder.LITTLE_ENDIAN)
+        // Request consists of 4 uint32 fields and one uint64 timestamp
+        // => 4*4 + 8 = 24 bytes
+        val bufReq = ByteBuffer.allocate(24).order(ByteOrder.LITTLE_ENDIAN)
         bufReq.putInt(count)
         val sendTime = System.nanoTime()
         bufReq.putLong(sendTime)


### PR DESCRIPTION
## Summary
- allocate correct size buffer for UDP request in Android client

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ff42c4148326b100705e352ad6e8