### PR TITLE
Fix request struct padding

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -42,6 +42,8 @@ static uint64_t now_ns() {
         Clock::now().time_since_epoch()).count();
 }
 
+// Same layout as used by the Android client (packed to 24 bytes).
+#pragma pack(push, 1)
 struct Request {
     uint32_t count;
     uint64_t client_time_ns;
@@ -49,6 +51,7 @@ struct Request {
     uint32_t payload_size;
     uint32_t tick_request_ms;
 };
+#pragma pack(pop)
 
 static void print_help(const char* prog) {
     std::cout << "Usage: " << prog

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -85,6 +85,10 @@ int main(int argc, char* argv[]) {
     std::strftime(fname, sizeof(fname), "server_%Y%m%d_%H%M%S.log", tm);
     std::ofstream log(fname);
 
+    // Layout must match the Android client which packs these fields without
+    // any padding (4*4 + 8 = 24 bytes). Use pragma pack to ensure the same
+    // size across architectures.
+    #pragma pack(push, 1)
     struct Request {
         uint32_t count;
         uint64_t client_time_ns;
@@ -92,6 +96,7 @@ int main(int argc, char* argv[]) {
         uint32_t payload_size;
         uint32_t tick_request_ms;
     };
+    #pragma pack(pop)
 
     while (true) {
         char buffer[1500];


### PR DESCRIPTION
## Summary
- ensure consistent `Request` struct layout across platforms

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685103a1fc388326a4b6e1df458fd000