### PR TITLE
Fix Android latency parsing and GraphView behavior

### DIFF
--- a/android-client/app/src/main/java/ar/com/telecom/speedtestgamer/MainActivity.kt
+++ b/android-client/app/src/main/java/ar/com/telecom/speedtestgamer/MainActivity.kt
@@ -44,6 +44,10 @@ class MainActivity : AppCompatActivity() {
         graph = findViewById(R.id.graph)
         graph.addSeries(series)
         series.spacing = 50
+        // enable scrolling of the graph when new data arrives
+        graph.viewport.isXAxisBoundsManual = true
+        graph.viewport.setMinX(0.0)
+        graph.viewport.setMaxX(50.0)
 
 
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -16,12 +16,16 @@
 
 using Clock = std::chrono::high_resolution_clock;
 
+// Packet header layout used by the server. Pack it so the size is 20 bytes
+// and consistent with the Android implementation.
+#pragma pack(push, 1)
 struct PacketHeader {
     uint32_t seq;
     uint64_t timestamp_ns;
     uint32_t server_id;
     uint32_t tick_ms;
 };
+#pragma pack(pop)
 
 struct Packet {
     uint32_t seq;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -12,12 +12,16 @@
 #include <unistd.h>
 #include <thread>
 
+// Header sent before every payload packet. Pack the structure so the size
+// matches the 20 bytes expected by the Android client.
+#pragma pack(push, 1)
 struct PacketHeader {
     uint32_t seq;
     uint64_t timestamp_ns;
     uint32_t server_id;
     uint32_t tick_ms;
 };
+#pragma pack(pop)
 
 struct Packet {
     uint32_t seq;


### PR DESCRIPTION
## Summary
- align `PacketHeader` across C++ and Android by packing to 20 bytes
- enable X axis bounds on Android chart so scrolling works

## Testing
- `make`
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510ceb2b548326ac2556e4d9be115b