### PR TITLE
Add periodic clock sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ An Android front end is provided in `android-client`. It mirrors the C++ client 
   * `uint32_t server_id` – identifier of the server.
   * `uint32_t tick_ms` – tick interval that will actually be used. Multiple `Sync`
     messages are sent so the client can pick the one with the smallest round-trip
-    time to estimate the clock offset.
+    time to estimate the clock offset. The server continues to send a sync message
+    every second while packets are transmitted so the client can refine the offset.
 * **Packet** (server ➜ client):
   * `uint32_t seq` – sequence number.
   * `uint64_t timestamp_ns` – server send timestamp in nanoseconds.


### PR DESCRIPTION
## Summary
- send sync messages every second while sending packets
- accept sync messages at any time and update offset if better
- show current offset in Android UI
- document new constant sync behaviour

## Testing
- `make clean && make`
- `./gradlew assembleDebug` *(fails: SDK not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68516e4c7c6c8326b18eede5be85f228