### PR TITLE
Add clock sync protocol and IP listing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Guidelines for Codex Agents
 
 - Always run `make` to build the server and client when changes are made to the C++ sources. Binaries are produced in the `dist/` directory.
-- If the Android client is modified, verify it builds with `./gradlew assembleDebug` inside `android-client`.
+- If the Android client is modified, verify it builds interactively with `./gradlew assembleDebug` inside `android-client`.
 - There are currently no automated tests. Ensure compilation succeeds without errors.
 - When adding features, keep the code portable and compatible with both x86_64 and ARM64 compilers.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -10,6 +10,7 @@
 #include <arpa/inet.h>
 #include <sys/socket.h>
 #include <unistd.h>
+#include <ifaddrs.h>
 #include <thread>
 #include <atomic>
 
@@ -32,22 +33,42 @@ struct Packet {
     std::vector<uint8_t> payload;
 };
 
-struct Sync {
-    uint64_t server_time_ns;
-    uint32_t server_id;
-    uint32_t tick_ms;
+struct SyncRequest {
+    uint64_t client_time_ns; // t0
 };
 
-constexpr int SYNC_COUNT = 5;
-constexpr int SYNC_INTERVAL_MS = 1000;
+struct SyncResponse {
+    uint64_t recv_time_ns; // t1
+    uint64_t send_time_ns; // t2
+};
 
 static uint64_t now_ns() {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::high_resolution_clock::now().time_since_epoch()).count();
 }
 
+static std::vector<std::string> get_ip_addresses() {
+    std::vector<std::string> ips;
+    ifaddrs* ifaddr;
+    if (getifaddrs(&ifaddr) == -1)
+        return ips;
+    for (ifaddrs* ifa = ifaddr; ifa; ifa = ifa->ifa_next) {
+        if (!ifa->ifa_addr || ifa->ifa_addr->sa_family != AF_INET)
+            continue;
+        sockaddr_in* sa = reinterpret_cast<sockaddr_in*>(ifa->ifa_addr);
+        char buf[INET_ADDRSTRLEN];
+        if (inet_ntop(AF_INET, &sa->sin_addr, buf, sizeof(buf)))
+            ips.emplace_back(buf);
+    }
+    freeifaddrs(ifaddr);
+    return ips;
+}
+
 static void print_help(const char* prog) {
-    std::cout << "Usage: " << prog << " [-p port] [-t tick_ms]\n";
+    std::cout << "Usage: " << prog << " [options]\n"
+              << "  -p, --port <port>  UDP port to listen on (default 9000)\n"
+              << "  -t, --tick <ms>    Interval between packets (ms)\n"
+              << "  -h, --help         Show this help message\n";
 }
 
 int main(int argc, char* argv[]) {
@@ -83,7 +104,10 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
-    std::cout << "Server listening on port " << port << std::endl;
+    auto ips = get_ip_addresses();
+    std::cout << "Server listening on";
+    for (const auto& ip : ips) std::cout << " " << ip;
+    std::cout << " port " << port << std::endl;
 
     const uint32_t server_id = 1;
     auto t = std::chrono::system_clock::now();
@@ -111,10 +135,25 @@ int main(int argc, char* argv[]) {
         sockaddr_in client{};
         socklen_t len = sizeof(client);
         ssize_t n = recvfrom(sock, buffer, sizeof(buffer), 0, (sockaddr*)&client, &len);
-        if (n < (ssize_t)sizeof(Request)) {
+        if (n < 0) {
             perror("recvfrom");
             continue;
         }
+
+        if (n == (ssize_t)sizeof(SyncRequest)) {
+            SyncRequest sreq;
+            std::memcpy(&sreq, buffer, sizeof(sreq));
+            SyncResponse resp;
+            resp.recv_time_ns = now_ns();
+            resp.send_time_ns = now_ns();
+            sendto(sock, &resp, sizeof(resp), 0, (sockaddr*)&client, len);
+            continue;
+        }
+
+        if (n < (ssize_t)sizeof(Request)) {
+            continue; // ignore unknown packet
+        }
+
         Request req;
         std::memcpy(&req, buffer, sizeof(req));
 
@@ -126,29 +165,10 @@ int main(int argc, char* argv[]) {
 
         uint32_t actual_tick = tick_ms > 0 ? tick_ms : req.tick_request_ms;
 
-        // send multiple sync messages so the client can pick the one with
-        // the smallest observed round-trip time for a better clock offset
-        Sync sync{now_ns(), server_id, actual_tick};
-        for (int i = 0; i < SYNC_COUNT; ++i) {
-            sendto(sock, &sync, sizeof(sync), 0, (sockaddr*)&client, len);
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
-        }
-
         uint32_t count = req.count;
         sockaddr_in client_copy = client;
         socklen_t len_copy = len;
         std::thread([sock, client_copy, len_copy, actual_tick, count, server_id, req]() mutable {
-            std::atomic<bool> running(true);
-            std::thread sync_thread([&] {
-                while (running.load()) {
-                    Sync periodic{now_ns(), server_id, actual_tick};
-                    sendto(sock, &periodic, sizeof(periodic), 0,
-                           (sockaddr*)&client_copy, len_copy);
-                    std::this_thread::sleep_for(
-                        std::chrono::milliseconds(SYNC_INTERVAL_MS));
-                }
-            });
-
             PacketHeader hdr{};
             std::vector<uint8_t> buf(sizeof(PacketHeader) + req.payload_size, 0);
             for (uint32_t i = 0; i < count; ++i) {
@@ -161,9 +181,6 @@ int main(int argc, char* argv[]) {
                 if (actual_tick > 0 && i + 1 < count)
                     std::this_thread::sleep_for(std::chrono::milliseconds(actual_tick));
             }
-
-            running = false;
-            sync_thread.join();
         }).detach();
     }
 }


### PR DESCRIPTION
## Summary
- implement new client-driven clock sync logic
- respond to sync requests in server and print local IPs on startup
- update Android client for new sync algorithm
- enhance help messages and documentation
- document build instructions for the agent

## Testing
- `make clean && make`
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_6851d3a378488326977af7f4e502fbfb